### PR TITLE
Fix typo in Chain::setLambdas

### DIFF
--- a/src/chain.hpp
+++ b/src/chain.hpp
@@ -161,7 +161,7 @@ inline void Chain::setLambdas(std::vector<double> & v)
     _statefreq_updater->setLambda(v[1]);
     _exchangeability_updater->setLambda(v[2]);
     _tree_updater->setLambda(v[3]);
-    _tree_length_updater->setLambda(v[3]);
+    _tree_length_updater->setLambda(v[4]);
     }
 
 inline void Chain::startTuning()


### PR DESCRIPTION
Hi Paul,

I recently discovered this great tutorial of yours, and have finally worked my way through to the end. I noticed, though, that with multiple chains my TreeLengthUpdater would always tune to the same lambda as my TreeUpdater, and accept nearly 100% of its proposals. Then I noticed that `Chain::setLambdas()` sets both updaters' lambdas to the same value:

```c++
inline void Chain::setLambdas(std::vector<double> & v)
    {
    assert(v.size() >= 4);
    _shape_updater->setLambda(v[0]);
    _statefreq_updater->setLambda(v[1]);
    _exchangeability_updater->setLambda(v[2]);
    _tree_updater->setLambda(v[3]);
    _tree_length_updater->setLambda(v[3]);  // <- same value
    }
```

If I change the last line to `_tree_length_updater->setLambda(v[4]);` this problem goes away and the acceptance rate drops back to 20-30%, so I think it fixes it. I've put the change in this pull request if you think it's useful.

Thanks again for the tutorial,
All the best,

Kevin